### PR TITLE
update props and vcxproj file to work with current Spinnaker lib

### DIFF
--- a/ofxSpinnakerLib/ofxSpinnaker.props
+++ b/ofxSpinnakerLib/ofxSpinnaker.props
@@ -7,7 +7,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(OF_ROOT)/addons/ofxSpinnaker/libs/Spinnaker/include;$(OF_ROOT)/addons/ofxSpinnaker/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(OF_ROOT)/addons/ofxSpinnaker/libs/Spinnaker/include;$(OF_ROOT)/addons/ofxSpinnaker/libs/Spinnaker/include/spinnaker;$(OF_ROOT)/addons/ofxSpinnaker/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/ofxSpinnakerLib/ofxSpinnaker.vcxproj
+++ b/ofxSpinnakerLib/ofxSpinnaker.vcxproj
@@ -82,7 +82,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -100,7 +100,7 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -120,7 +120,7 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -142,7 +142,7 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>false</SDLCheck>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
- disabled SDLCheck because there were some deprecated functions messages in the lib itself which were being treated as errors and preventing ofxSpinnaker.lib from being built.
- new header include path
Working with SpinnakerSDK_FULL_1.23.0.27_x64.exe